### PR TITLE
Fix: Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Upload CLAP plugin artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: clap-plugin-windows
           path: build/Release/*.clap # Assuming the plugin is in build/Release and has a .clap extension


### PR DESCRIPTION
The GitHub Actions build was failing due to the use of a deprecated version of the actions/upload-artifact action (v3).

This commit updates the workflow to use actions/upload-artifact@v4 to resolve the issue and ensure compatibility with future GitHub Actions updates.