### PR TITLE
Fix: Improve GitHub Actions workflow for Windows builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,13 +10,27 @@ jobs:
   build_windows:
     runs-on: windows-latest
     steps:
+      - name: Set Git safe directory
+        run: git config --global --add safe.directory '*'
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
 
       - name: Set up MSVC build tools
         uses: microsoft/setup-msbuild@v1.1
         with:
           msbuild-architecture: 'x64' # Assuming 64-bit build, can be adjusted
+
+      - name: Clean previous build artifacts
+        run: |
+          if (Test-Path build) {
+            Remove-Item -Recurse -Force build
+          }
+          if (Test-Path CMakeCache.txt) {
+            Remove-Item CMakeCache.txt
+          }
+        shell: pwsh
 
       - name: Configure CMake
         run: cmake -B build -S . -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
This commit addresses several issues observed in the Windows build process:

1.  **CMake Cache Cleaning:** Added a step to explicitly clean the CMake build directory (`build/`) and any existing `CMakeCache.txt` before running CMake configuration. This prevents stale cache variables from causing configuration errors, such as the one related to `juce-juce-juce/solar/include`.

2.  **Recursive Submodule Checkout:** Modified the `actions/checkout` step to include `submodules: 'recursive'`. This ensures that all Git submodules (like Skia, ImGui, CLAP, googletest) are properly initialized and updated, which is crucial for CMake to find their respective `CMakeLists.txt` files and headers.

3.  **Git Safe Directory:** Added a step to execute `git config --global --add safe.directory '*'` before other Git operations. This addresses potential Git errors related to directory ownership in the GitHub Actions environment, which were appearing during the "Post Job cleanup" phase.

These changes aim to make the Windows build process more robust and less prone to errors caused by inconsistent state or submodule issues. The `where.exe products` error is anticipated to be resolved as a side effect of a correct CMake configuration, but this will need to be confirmed by observing the next build.