### PR TITLE
Add GitHub Actions workflow for CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,9 +2,9 @@ name: Build and Test Plugin
 
 on:
   push:
-    # branches: [ main, master ] # Also common to include master
+    branches: [ main, master ] # Also common to include master
   pull_request:
-    # branches: [ main, master ]
+    branches: [ main, master ]
 
 jobs:
   build:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,10 +1,10 @@
 name: Build and Test Plugin
 
 on:
-#  push:
-#    branches: [ main, master ] # Also common to include master
+  push:
+    branches: [ main, master ] # Also common to include master
   pull_request:
-#    branches: [ main, master ]
+    branches: [ main, master ]
 
 jobs:
   build:
@@ -62,4 +62,4 @@ jobs:
       run: cmake --build build --config Release
 
     - name: Run tests
-      run: ctest --test-dir build --output-on-failure --config Release
+      run: ctest --test-dir build -C Release --output-on-failure

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,10 +1,10 @@
 name: Build and Test Plugin
 
 on:
-  push:
-    branches: [ main, master ] # Also common to include master
+  # push:
+    # branches: [ main, master ] # Also common to include master
   pull_request:
-    branches: [ main, master ]
+    # branches: [ main, master ]
 
 jobs:
   build:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,65 @@
+name: Build and Test Plugin
+
+on:
+  push:
+    branches: [ main, master ] # Also common to include master
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+
+    - name: Set up MSVC (Windows only)
+      if: runner.os == 'Windows'
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Configure CMake
+      run: cmake . -B build
+
+    - name: Build project
+      run: cmake --build build --config Release
+
+    - name: Upload Windows Artifact
+      if: runner.os == 'Windows'
+      uses: actions/upload-artifact@v4
+      with:
+        name: MyFirstClapPlugin-windows-${{ github.sha }}
+        path: build/Release/MyFirstClapPlugin.clap # Typical path for Release config with MSVC
+
+  test:
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    needs: build # Ensures build job completes before test job starts
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+
+    - name: Set up MSVC (Windows only)
+      if: runner.os == 'Windows'
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Configure CMake
+      run: cmake . -B build
+
+    - name: Build project (including tests)
+      run: cmake --build build --config Release
+
+    - name: Run tests
+      run: ctest --test-dir build --output-on-failure --config Release

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,10 +1,10 @@
 name: Build and Test Plugin
 
 on:
-  push:
-    branches: [ main, master ] # Also common to include master
+#  push:
+#    branches: [ main, master ] # Also common to include master
   pull_request:
-    branches: [ main, master ]
+#    branches: [ main, master ]
 
 jobs:
   build:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,9 +2,9 @@ name: Build and Test Plugin
 
 on:
   push:
-    branches: [ main, master ] # Also common to include master
+    # branches: [ main, master ] # Also common to include master
   pull_request:
-    branches: [ main, master ]
+    # branches: [ main, master ]
 
 jobs:
   build:

--- a/my_plugin.cpp
+++ b/my_plugin.cpp
@@ -16,6 +16,9 @@ static const void *my_plugin_get_extension(const struct clap_plugin *plugin, con
 static void my_plugin_on_main_thread(const struct clap_plugin *plugin);
 
 // --- Plugin Descriptor ---
+// Features array for the plugin descriptor
+static const char *const plugin_features[] = {"audio_effect", nullptr};
+
 static const clap_plugin_descriptor_t my_plugin_descriptor = {
     CLAP_VERSION,
     "com.example.myplugin", // id
@@ -26,7 +29,7 @@ static const clap_plugin_descriptor_t my_plugin_descriptor = {
     "https://example.com/support",    // support_url
     "0.0.1",                // version
     "A simple example CLAP audio plugin.", // description
-    (const char *const[]){"audio_effect", nullptr}, // features
+    plugin_features, // features
     // CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, // Example if using clap_plugin_features.h
 };
 


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow (`.github/workflows/build_and_test.yml`) to automate the build and testing process.

The workflow includes the following features:
- Builds the project on both Linux (ubuntu-latest) and Windows (windows-latest).
- Leverages CMake for configuration and building.
- Includes submodules (clap, googletest) in the checkout.
- Sets up the MSVC environment for Windows builds.
- Runs tests (via ctest) on both platforms after a successful build.
- Uploads the Windows build artifact (`MyFirstClapPlugin.clap`) for easy download.

This ensures that the project can be built on Linux and that Windows artifacts are available, fulfilling the issue requirements.