### PR TITLE
Fix: Correct VSTGUI unit test execution on Windows in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,7 +62,13 @@ jobs:
         echo "$PWD" >> $GITHUB_PATH
 
     - name: Configure CMake
-      run: cmake . -B build
+      shell: bash # Explicitly use bash for consistent if/else syntax
+      run: |
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          cmake . -B build -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=${{ github.workspace }}/build/libs/vstgui/vstgui/tests/unittest/Release
+        else
+          cmake . -B build
+        fi
 
     - name: Build project
       run: cmake --build build --config Release
@@ -137,10 +143,21 @@ jobs:
         echo "$PWD" >> $GITHUB_PATH
 
     - name: Configure CMake
-      run: cmake . -B build
+      shell: bash # Explicitly use bash for consistent if/else syntax
+      run: |
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          cmake . -B build -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=${{ github.workspace }}/build/libs/vstgui/vstgui/tests/unittest/Release
+        else
+          cmake . -B build
+        fi
 
     - name: Build project (including tests)
       run: cmake --build build --config Release
+
+    - name: Run VSTGUI Unit Tests (Windows)
+      if: runner.os == 'Windows'
+      run: ${{ github.workspace }}/build/libs/vstgui/vstgui/tests/unittest/Release/unittests.exe
+      working-directory: ${{ github.workspace }} # Ensure working directory if needed, though absolute path should be fine
 
     - name: Run tests
       run: ctest --test-dir build -C Release --output-on-failure


### PR DESCRIPTION
The VSTGUI submodule's post-build command to run unit tests was failing on Windows in GitHub Actions. This was due to CMAKE_RUNTIME_OUTPUT_DIRECTORY not being resolved correctly, leading to an MSB3073 error.

This commit fixes this by:
1. Setting CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE in the CMake configuration for Windows runners. This helps the submodule's post-build command find 'unittests.exe' and prevents the build error.
2. Adding a step in the 'test' job to explicitly run 'unittests.exe' on Windows, ensuring VSTGUI tests are executed.