### PR TITLE
Fix: Adjust plugin window decorations for embedded mode

### DIFF
--- a/my_plugin.cpp
+++ b/my_plugin.cpp
@@ -405,6 +405,13 @@ static bool my_plugin_gui_create(const clap_plugin_t *plugin, const char *api, b
     // Configure GLFW window hints
     glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE); // Start hidden
     glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
+
+    // Add conditional decoration hint
+    if (self->is_floating == false) {
+        glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);
+    } else {
+        glfwWindowHint(GLFW_DECORATED, GLFW_TRUE);
+    }
     
     // Create GLFW window
     self->window = glfwCreateWindow(


### PR DESCRIPTION
Modifies the GLFW window creation logic in the example plugin's GUI handling.

When a plugin GUI is created:
- If it's intended for embedded display (`is_floating` is false), it now requests a borderless window from GLFW using `glfwWindowHint(GLFW_DECORATED, GLFW_FALSE)`. This prevents the plugin from drawing its own title bar and borders when hosted within another application's window, leading to a cleaner look.
- If it's a floating window (`is_floating` is true), it explicitly requests a decorated window, maintaining standard behavior for floating plugin windows.

This addresses the issue where plugin windows might show unnecessary decorations when embedded by a CLAP host.